### PR TITLE
fix: specification grading set to 1 instead of 0 points

### DIFF
--- a/app/Services/CanvasService.php
+++ b/app/Services/CanvasService.php
@@ -352,7 +352,7 @@ class CanvasService
 
         return self::editAssignment($assessmentCourse,
             [
-                'points_possible' => $is_specification ? 0 : $assessmentCourse->assessment->questionCount(),
+                'points_possible' => $is_specification ? 1 : $assessmentCourse->assessment->questionCount(),
                 'grading_type' => $is_specification ? 'pass_fail' : 'points',
             ]
         );


### PR DESCRIPTION
Current behavior causes assignments' max amount of points to turn to 0. Students will receive a complete on the assignment but also a 0/0. 